### PR TITLE
fix: no import @types in deno.json

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -29,7 +29,6 @@
     "@std/async": "jsr:@std/async@0.224.1",
     "@std/log": "jsr:@std/log@0.224.1",
     "@std/testing": "jsr:@std/testing@0.224.0",
-    "@types/sinonjs__fake-timers": "npm:@types/sinonjs__fake-timers@^8.1.5",
     "bdd": "jsr:@std/testing@0.224.0/bdd"
   },
   "publish": {

--- a/deno.lock
+++ b/deno.lock
@@ -127,8 +127,7 @@
       "jsr:@std/async@0.224.1",
       "jsr:@std/log@0.224.1",
       "jsr:@std/testing@0.224.0",
-      "npm:@sinonjs/fake-timers@^11.2.2",
-      "npm:@types/sinonjs__fake-timers@^8.1.5"
+      "npm:@sinonjs/fake-timers@^11.2.2"
     ],
     "packageJson": {
       "dependencies": [

--- a/timers.ts
+++ b/timers.ts
@@ -1,4 +1,4 @@
-// @deno-types="@types/sinonjs__fake-timers"
+// @deno-types="npm:@types/sinonjs__fake-timers@^8.1.5"
 import {
   type FakeMethod,
   install,


### PR DESCRIPTION
Packages in special comments will not be replaced by `deno publish`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed dependency on `@types/sinonjs__fake-timers` to streamline the project.
  
- **Refactor**
	- Updated `@deno-types` directive to specify a more specific version of the `@types/sinonjs__fake-timers` dependency for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->