### PR TITLE
test: support deno@1.46

### DIFF
--- a/internal/timers.test.ts
+++ b/internal/timers.test.ts
@@ -8,8 +8,6 @@ import {
 } from "@std/assert";
 import { delayImmediate, FakeTime } from "./timers.ts";
 
-const origSetTimeout = setTimeout;
-
 describe("delayImmediate()", () => {
   it("should resolves all microtasks", async () => {
     const logs: string[] = [];
@@ -34,6 +32,7 @@ describe("delayImmediate()", () => {
 });
 
 describe("new FakeTime()", () => {
+  const origSetTimeout = setTimeout;
   it("should create instance of `FakeTime`", () => {
     const actual = new FakeTime();
     actual.restore();
@@ -48,8 +47,11 @@ describe("new FakeTime()", () => {
   });
 });
 describe("FakeTime", () => {
+  // deno-lint-ignore no-explicit-any
+  let origSetTimeout: (...args: any[]) => unknown;
   let instance: FakeTime;
   beforeEach(() => {
+    origSetTimeout = setTimeout;
     instance = new FakeTime();
   });
   afterEach(() => {


### PR DESCRIPTION
`setTimeout` is changed by node-integration during test execution.

```
FakeTime ... .restore() ... should restore `setTimeout` => https://jsr.io/@std/testing/0.225.3/_test_suite.ts:326:15
error: AssertionError: Values are not strictly equal.


    [Diff] Actual / Expected


-   [Function: setTimeout] {
-     [Symbol(nodejs.util.promisify.custom)]: [Function: value],
-   }
+   [Function: setTimeout]

  throw new AssertionError(message);
        ^
    at assertStrictEquals (https://jsr.io/@std/assert/1.0.1/strict_equals.ts:62:9)
    at Object.<anonymous> (file:///home/runner/work/ts-streamtest/ts-streamtest/internal/timers.test.ts:142:7)
    at Function.runTest (https://jsr.io/@std/testing/0.225.3/_test_suite.ts:361:16)
    at Function.runTest (https://jsr.io/@std/testing/0.225.3/_test_suite.ts:349:33)
    at Function.runTest (https://jsr.io/@std/testing/0.225.3/_test_suite.ts:349:33)
    at eventLoopTick (ext:core/01_core.js:174:7)
    at async fn (https://jsr.io/@std/testing/0.225.3/_test_suite.ts:319:13)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved organization and encapsulation of test variables for better clarity and maintainability.
	- Enhanced type safety for the `origSetTimeout` variable within the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->